### PR TITLE
Fix false positive for AWS secret access key

### DIFF
--- a/rules/aws/secret_access_key.yml
+++ b/rules/aws/secret_access_key.yml
@@ -1,7 +1,7 @@
 - id: sider.secrets.aws.secret_access_key
   pattern:
     regexp: |-
-      \b[A-Za-z0-9\/\+=]{40}\b
+      (?<!-)\b[A-Za-z0-9\/\+=]{40}\b
   glob:
     - "**/*"
   message: |
@@ -22,3 +22,4 @@
     - "_wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
     - "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1"
     - "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY_"
+    - "-wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
Ignore a text starting with a hyphen (`-`):

```console
$ goodcheck check package-lock.json
package-lock.json:16:28: It is dangerous to embed an AWS secret access key into your code.
      "integrity": "sha512-dm8UE0+9sbDRFJ6BMYpOrg56W3/wpZq2eBkGsCM+iSBrEKQF8hXFZ4eEEBxo25yfEPNVZguN/FbZcRmkeCyRiA==",
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
package-lock.json:50:28: It is dangerous to embed an AWS secret access key into your code.
      "integrity": "sha512-dm8UE0+9sbDRFJ6BMYpOrg56W3/wpZq2eBkGsCM+iSBrEKQF8hXFZ4eEEBxo25yfEPNVZguN/FbZcRmkeCyRiA==",
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```