### PR TITLE
Fix false positive for AWS secret access key

### DIFF
--- a/rules/aws/secret_access_key.yml
+++ b/rules/aws/secret_access_key.yml
@@ -1,7 +1,7 @@
 - id: sider.secrets.aws.secret_access_key
   pattern:
     regexp: |-
-      (?<![-/])\b[A-Za-z0-9\/\+=]{40}\b
+      (?<![-\/])\b[A-Za-z0-9\/\+=]{40}\b
   glob:
     - "**/*"
   message: |

--- a/rules/aws/secret_access_key.yml
+++ b/rules/aws/secret_access_key.yml
@@ -1,7 +1,7 @@
 - id: sider.secrets.aws.secret_access_key
   pattern:
     regexp: |-
-      (?<!-)\b[A-Za-z0-9\/\+=]{40}\b
+      (?<![-/])\b[A-Za-z0-9\/\+=]{40}\b
   glob:
     - "**/*"
   message: |
@@ -23,3 +23,4 @@
     - "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1"
     - "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY_"
     - "-wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    - "/wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
Ignore a text starting with a slash (`/`):

```console
$ goodcheck check .gitignore
.gitignore:1:45: It is dangerous to embed an AWS secret access key into your code.
### https://raw.github.com/github/gitignore/b2ccc4644b997fa2e86da5ae37f3b053c39f3d7b/Node.gitignore
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```