### PR TITLE
[RubyGems] Add rule for API key

### DIFF
--- a/rules/rubygems/api_key.yml
+++ b/rules/rubygems/api_key.yml
@@ -1,7 +1,7 @@
 - id: sider.secrets.rubygems.api_key
   pattern:
     regexp: |-
-      \brubygems_[A-Za-z0-9]{48,255}\b
+      \brubygems_[A-Za-z0-9]{48,255}
   severity: warning
   message: |
     It may be dangerous to commit the RubyGems API key.

--- a/rules/rubygems/api_key.yml
+++ b/rules/rubygems/api_key.yml
@@ -1,0 +1,29 @@
+- id: sider.secrets.rubygems.api_key
+  pattern:
+    regexp: |-
+      \brubygems_[A-Za-z0-9]{48,255}\b
+  severity: warning
+  message: |
+    It may be dangerous to commit the RubyGems API key.
+
+    Using a leaked API key, an attacker can embed malicious code to your gems and publish them.
+
+    See also:
+    * https://guides.rubygems.org/api-key-scopes/
+  justification:
+    - When this is not a RubyGems API key.
+    - When this leakage is not a problem. (such as test data)
+  fail:
+    - |-
+      rubygems_cec9db9373ea171daaaa0bf2337edce187f09558cb19c1b2
+    - |-
+      key=rubygems_cec9db9373ea171daaaa0bf2337edce187f09558cb19c1b2
+    - |-
+      key: rubygems_cec9db9373ea171daaaa0bf2337edce187f09558cb19c1b2
+    - |-
+      "rubygems_cec9db9373ea171daaaa0bf2337edce187f09558cb19c1b2"
+  pass:
+    - |-
+      rubygems_123
+    - |-
+      123_rubygems


### PR DESCRIPTION
https://guides.rubygems.org/api-key-scopes/

NOTE:
This API key pattern is undocumented, but an example is on the guide above.
Also, I confirm the pattern is actually used.