### PR TITLE
Detect new npm access token format in all files

### DIFF
--- a/rules/npm/access_token_new.yml
+++ b/rules/npm/access_token_new.yml
@@ -1,0 +1,24 @@
+- id: sider.secrets.npm.access_token_new
+  pattern:
+    regexp: |-
+      npm_[A-Za-z0-9]{36}
+  severity: warning
+  message: |
+    It may be dangerous to commit the npm access token.
+
+    Using a leaked token, an attacker can embed malicious code to your packages and publish them.
+
+    See also:
+    * https://docs.npmjs.com/about-access-tokens
+    * https://github.blog/2021-09-23-announcing-npms-new-access-token-format/
+  justification:
+    - When this is not a npm access token.
+    - When this leakage is not a problem. (such as test data)
+  fail:
+    - |-
+      //registry.npmjs.org/:_authToken=npm_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ
+    - |-
+      NPM_TOKEN=npm_OmID4mVUvMsyZNQG2VZ1H08RZzkR27gpJl0w
+  pass:
+    - |-
+      //registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
New token access format was introduced for npm:
https://github.blog/2021-09-23-announcing-npms-new-access-token-format/

We should be able to detect it.

Note that this PR does not remove the old npm token check:
https://github.com/sider/peterbald/blob/main/rules/npm/access_token.yml

Testing on this very repository: `goodcheck` was able to find the secret token candidate in the rule yaml files:
```shell
$ goodcheck check -R sider.secrets.npm.access_token_new
rules/npm/access_token_new.yml:19:40: It may be dangerous to commit the npm access token.  (sider.secrets.npm.access_token_new)  [warning]
      //registry.npmjs.org/:_authToken=npm_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  Justifications:
    • When this is not a npm access token.
    • When this leakage is not a problem. (such as test data)

rules/npm/access_token_new.yml:21:17: It may be dangerous to commit the npm access token.  (sider.secrets.npm.access_token_new)  [warning]
      NPM_TOKEN=npm_OmID4mVUvMsyZNQG2VZ1H08RZzkR27gpJl0w
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  Justifications:
    • When this is not a npm access token.
    • When this leakage is not a problem. (such as test data)


19 files inspected, 2 issues detected
```